### PR TITLE
- $WindowsVersion set to 24h2, can override by using -WindowsVersion …

### DIFF
--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -279,7 +279,7 @@ param(
     [ValidateSet(10, 11, 2016, 2019, 2022, 2025)]
     [int]$WindowsRelease = 11,
     [Parameter(Mandatory = $false)]
-    [string]$WindowsVersion = '23h2',
+    [string]$WindowsVersion = '24h2',
     [Parameter(Mandatory = $false)]
     [ValidateSet('x86', 'x64', 'arm64')]
     [string]$WindowsArch = 'x64',
@@ -2238,9 +2238,16 @@ function Get-KBLink {
         return
     }
 
+    # $guids = $results.Links |
+    # Where-Object ID -match '_link' |
+    # Where-Object { $_.OuterHTML -match ( "(?=.*" + ( $Filter -join ")(?=.*" ) + ")" ) } |
+    # ForEach-Object { $_.id.replace('_link', '') } |
+    # Where-Object { $_ -in $kbids }
+
     $guids = $results.Links |
     Where-Object ID -match '_link' |
     Where-Object { $_.OuterHTML -match ( "(?=.*" + ( $Filter -join ")(?=.*" ) + ")" ) } |
+    Select-Object -First 1 |
     ForEach-Object { $_.id.replace('_link', '') } |
     Where-Object { $_ -in $kbids }
 
@@ -2250,7 +2257,7 @@ function Get-KBLink {
     }
 
     foreach ($guid in $guids) {
-        Write-Verbose -Message "Downloading information for $guid"
+        # Write-Verbose -Message "Downloading information for $guid"
         $post = @{ size = 0; updateID = $guid; uidInfo = $guid } | ConvertTo-Json -Compress
         $body = @{ updateIDs = "[$post]" }
         $OriginalVerbosePreference = $VerbosePreference
@@ -2321,35 +2328,35 @@ function Save-KB {
         $links = Get-KBLink -Name $kb
         foreach ($link in $links) {
             if (!($link -match 'x64' -or $link -match 'amd64' -or $link -match 'x86' -or $link -match 'arm64')) {
-                WriteLog "No architecture found in $link, assume this is for all architectures"
+                WriteLog "No architecture found in $link, skipping"
                 #FIX: 3/22/2024 - the SecurityHealthSetup fix was updated and now includes two files (one is x64 and the other is arm64)
                 #Unfortunately there is no easy way to determine the architecture from the file name
                 #There is a support doc that include links to download, but it's out of date (n-1)
                 #https://support.microsoft.com/en-us/topic/windows-security-update-a6ac7d2e-b1bf-44c0-a028-41720a242da3
                 #These files don't change that often, so will check the link above to see when it updates and may use that
                 #For now this is hard-coded for these specific file names
-                if ($link -match 'security') {
-                    #Make sure we're getting the correct architecture for the Security Health Setup update
-                    WriteLog "Link: $link matches security"
-                    if ($WindowsArch -eq 'x64') {
-                        if ($link -match 'securityhealthsetup_e1') {
-                            Writelog "Downloading $Link for $WindowsArch to $Path"
-                            Start-BitsTransferWithRetry -Source $link -Destination $Path
-                            $fileName = ($link -split '/')[-1]
-                            Writelog "Returning $fileName"
-                            break
-                        }
-                    }
-                    if ($WindowsArch -eq 'arm64') {
-                        if ($link -match 'securityhealthsetup_25') {
-                            Writelog "Downloading $Link for $WindowsArch to $Path"
-                            Start-BitsTransferWithRetry -Source $link -Destination $Path
-                            $fileName = ($link -split '/')[-1]
-                            Writelog "Returning $fileName"
-                            break
-                        }
-                    }
-                }
+            #     if ($link -match 'security') {
+            #         #Make sure we're getting the correct architecture for the Security Health Setup update
+            #         WriteLog "Link: $link matches security"
+            #         if ($WindowsArch -eq 'x64') {
+            #             if ($link -match 'securityhealthsetup_e1') {
+            #                 Writelog "Downloading $Link for $WindowsArch to $Path"
+            #                 Start-BitsTransferWithRetry -Source $link -Destination $Path
+            #                 $fileName = ($link -split '/')[-1]
+            #                 Writelog "Returning $fileName"
+            #                 break
+            #             }
+            #         }
+            #         if ($WindowsArch -eq 'arm64') {
+            #             if ($link -match 'securityhealthsetup_25') {
+            #                 Writelog "Downloading $Link for $WindowsArch to $Path"
+            #                 Start-BitsTransferWithRetry -Source $link -Destination $Path
+            #                 $fileName = ($link -split '/')[-1]
+            #                 Writelog "Returning $fileName"
+            #                 break
+            #             }
+            #         }
+            #     }
             }
 
             if ($link -match 'x64' -or $link -match 'amd64') {
@@ -2359,7 +2366,8 @@ function Save-KB {
                         Start-BitsTransferWithRetry -Source $link -Destination $Path
                         $fileName = ($link -split '/')[-1]
                         Writelog "Returning $fileName"
-                        break
+                        #With Windows 11 24H2 and Checkpoint CUs, there are multiple files that are downloaded
+                        # break
                     }
                 }
                 
@@ -2370,7 +2378,8 @@ function Save-KB {
                     Start-BitsTransferWithRetry -Source $link -Destination $Path
                     $fileName = ($link -split '/')[-1]
                     Writelog "Returning $fileName"
-                    break
+                    #With Windows 11 24H2 and Checkpoint CUs, there are multiple files that are downloaded
+                    # break
                 }
             }                
         }
@@ -3265,12 +3274,12 @@ Function Get-USBDrive {
             if ($VerbosePreference -ne 'Continue') {
                 Write-Host "Found $USBDrivesCount total USB drives"
                 If ($ExternalCount -gt 0) {
-                    Write-Host "$ExternalCount are external drives"
+                    Write-Host "$ExternalCount external drives"
                 }
             }
             WriteLog "Found $USBDrivesCount total USB drives"
             If ($ExternalCount -gt 0) {
-                WriteLog "$ExternalCount are external drives"
+                WriteLog "$ExternalCount external drives"
             }
         }
     }
@@ -4020,7 +4029,12 @@ if ($InstallApps) {
         }
         if ($UpdateLatestMSRT) {
             WriteLog "`$UpdateLatestMSRT is set to true."
-            $Name = "Windows Malicious Software Removal Tool"
+            if ($WindowsArch -eq 'x64') {
+                $Name = """Windows Malicious Software Removal Tool x64""" + " " + """Windows $WindowsRelease""" 
+            }
+            if ($WindowsArch -eq 'x86') {
+                $Name = """Windows Malicious Software Removal Tool""" + " " + """Windows $WindowsRelease""" 
+            }
             #Check if $MSRTPath exists, if not, create it
             if (-not (Test-Path -Path $MSRTPath)) {
                 WriteLog "Creating $MSRTPath"


### PR DESCRIPTION
…23H2 if you want the old behavior

- Removed the "Downloading information GUID" messages when downloading content from the Microsoft Update Catalog while -verbose was specified in the command line
- In Get-KBLink, made a change to just grab the first result returned instead of the entire results page. This removes the need to use a break statement in Save-KB when downloading updates. This fixed an issue with the new 24H2 Checkpoint Cumulative Updates in Win11 and Server 2025.
- Changed Windows MSRT search string for x64 and x86. This was mainly to get x64 to the top of the search results. x86 won't actually download since the code isn't in place for content from the MU Catalog to download x86 content (no idea if anyone actually builds x86 FFUs for Win10 - I hope not)